### PR TITLE
Support Metrics Service Endpoint

### DIFF
--- a/src/main/java/io/harness/cf/client/api/CfClient.java
+++ b/src/main/java/io/harness/cf/client/api/CfClient.java
@@ -21,6 +21,7 @@ import io.jsonwebtoken.Jwts;
 import java.io.Closeable;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,7 @@ public class CfClient implements Closeable {
   private SSEListener listener;
   private ServerSentEvent sse;
   private AnalyticsManager analyticsManager;
+  @Getter private boolean isInitialized;
 
   public CfClient(String apiKey) {
     this(apiKey, Config.builder().build());
@@ -62,6 +64,8 @@ public class CfClient implements Closeable {
 
     this.defaultApi = DefaultApiFactory.create(apiKey, config.getBaseUrl());
 
+    this.isInitialized = false;
+
     // try to authenticate
     AuthService authService =
         new AuthService(defaultApi, apiKey, this, config.getPollIntervalInSec());
@@ -76,7 +80,7 @@ public class CfClient implements Closeable {
 
     initCache(environmentID);
     if (!config.isStreamEnabled()) {
-      poller.startAsync();
+      startPollingMode();
       log.info("Running in polling mode.");
     } else {
       initStreamingMode();
@@ -86,6 +90,7 @@ public class CfClient implements Closeable {
 
     analyticsManager =
         config.isAnayticsEnabled() ? new AnalyticsManager(environmentID, apiKey, config) : null;
+    this.isInitialized = true;
   }
 
   private void initCache(String environmentID) throws io.harness.cf.ApiException {
@@ -158,7 +163,7 @@ public class CfClient implements Closeable {
       log.error("err", e);
       return defaultValue;
     } finally {
-      if (!target.isPrivate() && isAnalyticsEnabled) {
+      if (!target.isPrivate() && isAnalyticsEnabled && (analyticsManager != null)) {
         analyticsManager.pushToQueue(target, featureConfig, servedVariation);
       }
     }
@@ -186,7 +191,7 @@ public class CfClient implements Closeable {
       log.error("err", e);
       return defaultValue;
     } finally {
-      if (!target.isPrivate() && isAnalyticsEnabled) {
+      if (!target.isPrivate() && isAnalyticsEnabled && (analyticsManager != null)) {
         analyticsManager.pushToQueue(target, featureConfig, stringVariation);
       }
     }
@@ -214,7 +219,7 @@ public class CfClient implements Closeable {
       log.error("err", e);
       return defaultValue;
     } finally {
-      if (!target.isPrivate() && isAnalyticsEnabled) {
+      if (!target.isPrivate() && isAnalyticsEnabled && (analyticsManager != null)) {
         analyticsManager.pushToQueue(target, featureConfig, numberVariation);
       }
     }
@@ -243,7 +248,7 @@ public class CfClient implements Closeable {
       log.error("err", e);
       return defaultValue;
     } finally {
-      if (!target.isPrivate() && isAnalyticsEnabled) {
+      if (!target.isPrivate() && isAnalyticsEnabled && (analyticsManager != null)) {
         analyticsManager.pushToQueue(target, featureConfig, jsonObject);
       }
     }

--- a/src/main/java/io/harness/cf/client/api/Config.java
+++ b/src/main/java/io/harness/cf/client/api/Config.java
@@ -12,10 +12,13 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class Config {
-  public static final int MAX_FREQUENCY = 60;
+  public static final int MIN_FREQUENCY = 60;
 
   @Builder.Default
   private String baseUrl = "https://config.feature-flags.uat.harness.io/api/1.0"; // UAT
+
+  @Builder.Default
+  private String eventUrl = "https://config.feature-flags.uat.harness.io/api/1.0"; // UAT
 
   @Builder.Default private boolean streamEnabled = true;
   @Builder.Default private int pollIntervalInSec = 10;
@@ -39,7 +42,7 @@ public class Config {
   @Builder.Default private Set<String> privateAttributes = Collections.emptySet();
 
   public int getFrequency() {
-    return Math.max(frequency, Config.MAX_FREQUENCY);
+    return Math.max(frequency, Config.MIN_FREQUENCY);
   }
 
   /*

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -216,9 +216,9 @@ public class Evaluator {
       field.setAccessible(true);
       return field.get(target);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      Map<String, Object> customFields = target.getCustom();
+      Map<String, Object> customFields = target.getAttributes();
       if (customFields != null) {
-        for (Map.Entry<String, Object> entry : target.getCustom().entrySet()) {
+        for (Map.Entry<String, Object> entry : target.getAttributes().entrySet()) {
           if (entry.getKey().equals(attribute)) {
             return entry.getValue();
           }

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsManager.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsManager.java
@@ -29,7 +29,7 @@ public class AnalyticsManager {
       throws CfClientException {
     this.analyticsCache = AnalyticsCacheFactory.create(config.getAnalyticsCacheType());
     AnalyticsPublisherService analyticsPublisherService =
-        new AnalyticsPublisherService(apiKey, config.getBaseUrl(), environmentID, analyticsCache);
+        new AnalyticsPublisherService(apiKey, config, environmentID, analyticsCache);
     ringBuffer = createRingBuffer(config.getBufferSize(), analyticsPublisherService);
     ScheduledExecutorService timerExecutorService = Executors.newSingleThreadScheduledExecutor();
     TimerTask timerTask = new TimerTask(ringBuffer);

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.api.analytics;
 
 import io.harness.cf.client.api.CfClientException;
+import io.harness.cf.client.api.Config;
 import io.harness.cf.client.dto.Analytics;
 import io.harness.cf.client.dto.Target;
 import io.harness.cf.metrics.ApiException;
@@ -48,9 +49,10 @@ public class AnalyticsPublisherService {
   private final String environmentID;
 
   public AnalyticsPublisherService(
-      String apiKey, String baseUrl, String environmentID, Cache analyticsCache)
+      String apiKey, Config config, String environmentID, Cache analyticsCache)
       throws CfClientException {
-    metricsAPI = MetricsApiFactory.create(apiKey, baseUrl);
+
+    metricsAPI = MetricsApiFactory.create(apiKey, config.getEventUrl(), config.getBaseUrl());
     this.analyticsCache = analyticsCache;
     this.environmentID = environmentID;
   }
@@ -82,7 +84,7 @@ public class AnalyticsPublisherService {
         // Clear the set because the cache is only invalidated when there is no exception, so the
         // targets will reappear in the next
         // iteration
-        log.error("Failed to send metricsData {}", e.getCode());
+        log.error("Failed to send metricsData {} : {}", e.getMessage(), e.getCode());
       }
     }
   }
@@ -104,7 +106,7 @@ public class AnalyticsPublisherService {
       final Object variation = analytics.getVariation();
       if (!globalTargetSet.contains(target) && !target.isPrivate()) {
         stagingTargetSet.add(target);
-        final Map<String, Object> attributes = target.getCustom();
+        final Map<String, Object> attributes = target.getAttributes();
         attributes.forEach(
             (k, v) -> {
               KeyValue keyValue = new KeyValue();

--- a/src/main/java/io/harness/cf/client/api/analytics/MetricsApiFactory.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/MetricsApiFactory.java
@@ -26,12 +26,12 @@ public class MetricsApiFactory {
   private static final int AUTH_RETRY_MAX_RETRY_COUNT = 3;
 
   @SneakyThrows
-  public static DefaultApi create(String apiKey, String basePath) {
+  public static DefaultApi create(String apiKey, String basePath, String authUrl) {
     if (Strings.isNullOrEmpty(apiKey)) {
       throw new CfClientException("SDK key cannot be empty");
     }
     DefaultApi metricsAPI = new DefaultApi();
-    io.harness.cf.api.DefaultApi clientAPI = DefaultApiFactory.create(apiKey, basePath);
+    io.harness.cf.api.DefaultApi clientAPI = DefaultApiFactory.create(apiKey, authUrl);
     if (!Strings.isNullOrEmpty(basePath)) {
       ApiClient apiClient = metricsAPI.getApiClient();
       apiClient.setBasePath(basePath);

--- a/src/main/java/io/harness/cf/client/dto/Target.java
+++ b/src/main/java/io/harness/cf/client/dto/Target.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 public class Target {
   private String identifier;
   private String name;
-  private Map<String, Object> custom;
+  private Map<String, Object> attributes;
   private boolean isPrivate; // If the target is private
   private Set<String> privateAttributes; // Custom set to set the attributes which are private
 

--- a/src/main/java/io/harness/cf/client/example/Example.java
+++ b/src/main/java/io/harness/cf/client/example/Example.java
@@ -20,7 +20,7 @@ public class Example {
         Target.builder()
             .identifier("target2")
             // .identifier("hannah")
-            .custom(
+            .attributes(
                 new ImmutableMap.Builder<String, Object>()
                     .put("accountId", "kmpySmUISimoRrJL6NL73w")
                     .put("name", "ObjectName5")
@@ -32,7 +32,7 @@ public class Example {
     Target target1 =
         Target.builder()
             .identifier("subir")
-            .custom(
+            .attributes(
                 new ImmutableMap.Builder<String, Object>()
                     .put("accountId", "ampySmUISimoRrJL1NL73u")
                     .put("name", "ObjectName1")

--- a/src/test/java/io/harness/cf/client/api/CfClientTest.java
+++ b/src/test/java/io/harness/cf/client/api/CfClientTest.java
@@ -16,8 +16,9 @@ public class CfClientTest {
   private final CfClient cfClient;
   private Target target =
       Target.builder()
+          .name("target1")
           .identifier("target1-identifier")
-          .custom(
+          .attributes(
               new ImmutableMap.Builder<String, Object>()
                   .put("accountId", "kmpySmUISimoRrJL6NL73w")
                   .put("name", "ObjectName5")
@@ -27,31 +28,45 @@ public class CfClientTest {
 
   public CfClientTest()
       throws CfClientException, ApiException, IOException, XmlPullParserException {
-    // local
-    String apiKey = "76320784-d40b-4d26-ac31-f1703c56f478";
+
+    // local settings
+    String apiKey = "669f4aac-15cc-469c-8c97-d911a4d9a5fe";
+    String baseUrl = "http://35.233.208.131/api/1.0";
+    String eventsUrl = "http://34.83.43.198/api/1.0";
+
     cfClient =
         new CfClient(
             apiKey,
-            Config.builder().baseUrl("http://localhost:7999/api/1.0").streamEnabled(true).build());
+            Config.builder()
+                .baseUrl(baseUrl)
+                .eventUrl(eventsUrl)
+                .streamEnabled(true)
+                .anayticsEnabled(true)
+                .build());
 
-    // qb
-    //      String apiKey = "1734c427-0a9f-4e2e-92a7-5e04c7dec151";
-    //      cfClient = new CfClient(apiKey, Config.builder()
-    //              .baseUrl("https://qb.harness.io/cf").build());
+    // Wait for the client to be initialized
+    int retries = 5;
+    while (!cfClient.isInitialized() && retries > 0) {
+      try {
+        Thread.sleep(2000);
+        --retries;
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
 
-    // uat
-    //    String apiKey = "b36d5e5a-4fa8-11eb-ae93-0242ac130002";
-    //    cfClient = new CfClient(apiKey);
+    if (cfClient.isInitialized() != true) {
+      throw new CfClientException("Unable to initialize client with feature flag server");
+    }
   }
 
   @Test
-  @Ignore
   public void boolVariation() {
     // String FEATURE_FLAG_KEY = "Test";
     // String FEATURE_FLAG_KEY = "show_animation";
     String FEATURE_FLAG_KEY = "enable_anomaly_detection_batch_job";
 
-    IntStream.range(0, 500)
+    IntStream.range(0, 1)
         .forEach(
             i -> {
               boolean result = cfClient.boolVariation(FEATURE_FLAG_KEY, target, false);

--- a/src/test/java/io/harness/cf/client/api/CfClientTest.java
+++ b/src/test/java/io/harness/cf/client/api/CfClientTest.java
@@ -66,7 +66,7 @@ public class CfClientTest {
     // String FEATURE_FLAG_KEY = "show_animation";
     String FEATURE_FLAG_KEY = "enable_anomaly_detection_batch_job";
 
-    IntStream.range(0, 1)
+    IntStream.range(0, 500)
         .forEach(
             i -> {
               boolean result = cfClient.boolVariation(FEATURE_FLAG_KEY, target, false);


### PR DESCRIPTION
This change introducse a new url endpoint for the metrics server.
This means the metric server can be deployed independently of the client server.

This commit also addresses a bug where the analytics service may not be initalized
if we failed to validate the API key.

The Target custom field has been renamed attributes