### PR TITLE
[FFM-842]: adding support for variation identifier in the analyticsService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>0.0.7</version>
+    <version>0.0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -21,26 +21,26 @@ public class Evaluator {
     this.segmentCache = segmentCache;
   }
 
-  public Object evaluate(FeatureConfig featureConfig, Target target) throws CfClientException {
+  public Variation evaluate(FeatureConfig featureConfig, Target target) throws CfClientException {
     String servedVariation = featureConfig.getOffVariation();
     if (featureConfig.getState() == FeatureState.OFF) {
-      return getVariationValue(featureConfig.getVariations(), servedVariation);
+      return getVariation(featureConfig.getVariations(), servedVariation);
     }
 
     servedVariation = processVariationMap(target, featureConfig.getVariationToTargetMap());
     if (servedVariation != null) {
-      return getVariationValue(featureConfig.getVariations(), servedVariation);
+      return getVariation(featureConfig.getVariations(), servedVariation);
     }
 
     servedVariation = processRules(featureConfig, target);
     if (servedVariation != null) {
-      return getVariationValue(featureConfig.getVariations(), servedVariation);
+      return getVariation(featureConfig.getVariations(), servedVariation);
     }
 
     Serve defaultServe = featureConfig.getDefaultServe();
     servedVariation = processDefaultServe(defaultServe, target);
 
-    return getVariationValue(featureConfig.getVariations(), servedVariation);
+    return getVariation(featureConfig.getVariations(), servedVariation);
   }
 
   private String processVariationMap(Target target, List<VariationMap> variationMaps) {
@@ -217,11 +217,11 @@ public class Evaluator {
     return servedVariation;
   }
 
-  private String getVariationValue(List<Variation> variations, String variationIdentifier)
+  private Variation getVariation(List<Variation> variations, String variationIdentifier)
       throws CfClientException {
     for (Variation variation : variations) {
       if (variationIdentifier.equals(variation.getIdentifier())) {
-        return variation.getValue();
+        return variation;
       }
     }
     throw new CfClientException(format("Invalid variation identifier %s.", variationIdentifier));

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
@@ -11,6 +11,7 @@ import io.harness.cf.metrics.model.Metrics;
 import io.harness.cf.metrics.model.MetricsData;
 import io.harness.cf.metrics.model.TargetData;
 import io.harness.cf.model.FeatureConfig;
+import io.harness.cf.model.Variation;
 import io.jsonwebtoken.lang.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -27,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 public class AnalyticsPublisherService {
   private static final String FEATURE_NAME_ATTRIBUTE = "featureName";
   private static final String FEATURE_VALUE_ATTRIBUTE = "featureValue";
+  private static final String VARIATION_VALUE_ATTRIBUTE = "featureValue";
+  private static final String VARIATION_IDENTIFIER_ATTRIBUTE = "variationIdentifier";
   private static final String TARGET_ATTRIBUTE = "target";
   private static final Set<Target> globalTargetSet = new HashSet<>();
   private static final Set<Target> stagingTargetSet = new HashSet<>();
@@ -96,7 +99,7 @@ public class AnalyticsPublisherService {
       final Set<String> privateAttributes = analytics.getTarget().getPrivateAttributes();
       final Target target = analytics.getTarget();
       final FeatureConfig featureConfig = analytics.getFeatureConfig();
-      final Object variation = analytics.getVariation();
+      final Variation variation = analytics.getVariation();
       if (!globalTargetSet.contains(target) && !target.isPrivate()) {
         stagingTargetSet.add(target);
         final Map<String, Object> attributes = target.getAttributes();
@@ -123,7 +126,10 @@ public class AnalyticsPublisherService {
       metricsData.count(entry.getValue());
       metricsData.setMetricsType(MetricsData.MetricsTypeEnum.FFMETRICS);
       setMetricsAttriutes(metricsData, FEATURE_NAME_ATTRIBUTE, featureConfig.getFeature());
-      setMetricsAttriutes(metricsData, FEATURE_VALUE_ATTRIBUTE, variation.toString());
+      // TODO : deprecate this field FEATURE_VALUE_ATTRIBUTE in the subsequent releases
+      setMetricsAttriutes(metricsData, FEATURE_VALUE_ATTRIBUTE, variation.getValue());
+      setMetricsAttriutes(metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, variation.getIdentifier());
+      setMetricsAttriutes(metricsData, VARIATION_VALUE_ATTRIBUTE, variation.getValue());
       if (target.isPrivate()) {
         setMetricsAttriutes(metricsData, TARGET_ATTRIBUTE, ANONYMOUS_TARGET);
       } else {

--- a/src/main/java/io/harness/cf/client/dto/Analytics.java
+++ b/src/main/java/io/harness/cf/client/dto/Analytics.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.dto;
 
 import io.harness.cf.model.FeatureConfig;
+import io.harness.cf.model.Variation;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,6 @@ import lombok.ToString;
 public class Analytics {
   private FeatureConfig featureConfig;
   private Target target;
-  private Object variation;
+  private Variation variation;
   private EventType eventType = EventType.METRICS;
 }


### PR DESCRIPTION
Currently we do not send the variation identifier in the metricsService. This enhancement will send variationIdentifier as well as the variationValue in the metrics data. We will deprecate the featureValue attribute in the subsequent releases.