### PR TITLE
[FFM-1060]: remove variation value from being published to the metrics server

### DIFF
--- a/src/main/java/io/harness/cf/client/Example.java
+++ b/src/main/java/io/harness/cf/client/Example.java
@@ -1,6 +1,5 @@
 package io.harness.cf.client;
 
-import com.google.common.collect.ImmutableMap;
 import io.harness.cf.client.api.CfClient;
 import io.harness.cf.client.dto.Target;
 import lombok.extern.slf4j.Slf4j;
@@ -9,16 +8,15 @@ import lombok.extern.slf4j.Slf4j;
 class Example {
 
   public static final String FEATURE_FLAG_KEY = "toggle";
-  public static final String API_KEY = "8b3bf1d0-6c88-4cdb-99a1-36aff131911a";
+  public static final String API_KEY = "dummyKey";
 
   public static void main(String... args) {
     CfClient cfClient = new CfClient(API_KEY);
     Target target =
         Target.builder()
             .identifier("target1")
-            .attributes(
-                new ImmutableMap.Builder<String, Object>().put("licenseType", "TRIAL").build())
             .isPrivate(false)
+            .attribute("testKey", "TestValue")
             .name("target1")
             .build();
     boolean result = cfClient.boolVariation(FEATURE_FLAG_KEY, target, false);

--- a/src/main/java/io/harness/cf/client/api/AuthService.java
+++ b/src/main/java/io/harness/cf/client/api/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService extends AbstractScheduledService {
       cfClient.init();
       this.stopAsync();
     } catch (ApiException apiException) {
-      if (apiException.getCode() == 401) {
+      if (apiException.getCode() == 401 || apiException.getCode() == 403) {
         String errorMsg = String.format("Invalid apiKey %s. Serving default value. ", apiKey);
         log.error(errorMsg);
         throw new CfClientException(errorMsg);

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 public class AnalyticsPublisherService {
 
   private static final String FEATURE_NAME_ATTRIBUTE = "featureName";
-  private static final String VARIATION_VALUE_ATTRIBUTE = "featureValue";
   private static final String VARIATION_IDENTIFIER_ATTRIBUTE = "variationIdentifier";
   private static final String TARGET_ATTRIBUTE = "target";
   private static final Set<Target> globalTargetSet = new HashSet<>();
@@ -121,8 +120,6 @@ public class AnalyticsPublisherService {
       setMetricsAttriutes(metricsData, FEATURE_NAME_ATTRIBUTE, entry.getKey().getFeatureName());
       setMetricsAttriutes(
           metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, entry.getKey().getVariationIdentifier());
-      setMetricsAttriutes(
-          metricsData, VARIATION_VALUE_ATTRIBUTE, entry.getKey().getVariationValue());
       setMetricsAttriutes(metricsData, TARGET_ATTRIBUTE, GLOBAL_TARGET);
       setMetricsAttriutes(metricsData, JAR_VERSION, jarVerion);
       setMetricsAttriutes(metricsData, SDK_TYPE, SERVER);
@@ -161,7 +158,6 @@ public class AnalyticsPublisherService {
       metricsData.setMetricsType(MetricsData.MetricsTypeEnum.FFMETRICS);
       setMetricsAttriutes(metricsData, FEATURE_NAME_ATTRIBUTE, featureConfig.getFeature());
       setMetricsAttriutes(metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, variation.getIdentifier());
-      setMetricsAttriutes(metricsData, VARIATION_VALUE_ATTRIBUTE, variation.getValue());
       if (target.isPrivate()) {
         setMetricsAttriutes(metricsData, TARGET_ATTRIBUTE, ANONYMOUS_TARGET);
       } else {

--- a/src/main/java/io/harness/cf/client/dto/Target.java
+++ b/src/main/java/io/harness/cf/client/dto/Target.java
@@ -1,16 +1,15 @@
 package io.harness.cf.client.dto;
 
 import com.google.common.base.Strings;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Builder.Default;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.Singular;
 
 @Builder
 @Getter
@@ -23,8 +22,10 @@ public class Target {
   private String name;
   private String identifier;
 
-  @Default private Map<String, Object> attributes = new HashMap<>();
+  @Singular private Map<String, Object> attributes;
   private boolean isPrivate; // If the target is private
+
+  @Singular
   private Set<String> privateAttributes; // Custom set to set the attributes which are private
 
   @Override
@@ -34,7 +35,6 @@ public class Target {
   }
 
   public boolean isValid() {
-
     return !Strings.isNullOrEmpty(identifier);
   }
 }


### PR DESCRIPTION
Also added a helper method for targetbuilder attributes and privateAttributes so we can pass in single values rather than entire maps and sets