### PR TITLE
[FFM-1356]: Determine if a target should be included in a segment

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -46,7 +46,8 @@ public class Evaluator implements Evaluation {
     return getVariation(featureConfig.getVariations(), servedVariation);
   }
 
-  private String processVariationMap(Target target, List<VariationMap> variationMaps) {
+  private String processVariationMap(Target target, List<VariationMap> variationMaps)
+      throws CfClientException {
 
     if (variationMaps == null) {
       return null;
@@ -67,20 +68,8 @@ public class Evaluator implements Evaluation {
 
       List<String> segmentIdentifiers = variationMap.getTargetSegments();
       if (segmentIdentifiers != null) {
-        for (String segmentIdentifier : segmentIdentifiers) {
-          Segment segment = segmentCache.getIfPresent(segmentIdentifier);
-          if (segment != null) {
-            List<io.harness.cf.model.Target> includedTargets = segment.getIncluded();
-            if (includedTargets != null) {
-              Iterator<io.harness.cf.model.Target> iterator = includedTargets.iterator();
-              while (iterator.hasNext()) {
-                io.harness.cf.model.Target includedTarget = iterator.next();
-                if (includedTarget.getIdentifier().contains(target.getIdentifier())) {
-                  return variationMap.getVariation();
-                }
-              }
-            }
-          }
+        if (isTargetIncludedBySegment(segmentIdentifiers, target)) {
+          return variationMap.getVariation();
         }
       }
     }


### PR DESCRIPTION
What:
When a flag is being evaluated, that has been direcltly added to a segment,
we now call `isTargetIncludedBySegment()`  to ensure we check the
include, exclude and custom rules for matching targets to segments.

Why:
Previously we only checked if a target was matched to a segment with the include list.
We didn't evaluate the exclude list or custom rules.