### PR TITLE
[FFM-1358]: Analytics manager fails to start when debug is enabled

### DIFF
--- a/src/main/java/io/harness/cf/client/api/DefaultApiFactory.java
+++ b/src/main/java/io/harness/cf/client/api/DefaultApiFactory.java
@@ -5,20 +5,12 @@ import io.harness.cf.ApiClient;
 import io.harness.cf.api.DefaultApi;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @UtilityClass
 public class DefaultApiFactory {
-
-  @SneakyThrows
-  public static DefaultApi create(
-      String basePath, int connectionTimeout, int readTimeout, int writeTimeout) {
-    DefaultApi defaultApi = new DefaultApi();
-    return create(basePath, connectionTimeout, readTimeout, writeTimeout, false);
-  }
 
   public static DefaultApi create(
       String basePath, int connectionTimeout, int readTimeout, int writeTimeout, boolean debug) {

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsManager.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsManager.java
@@ -10,6 +10,7 @@ import io.harness.cf.client.common.Destroyable;
 import io.harness.cf.client.dto.Analytics;
 import io.harness.cf.client.dto.EventType;
 import io.harness.cf.client.dto.Target;
+import io.harness.cf.metrics.api.DefaultApi;
 import io.harness.cf.model.FeatureConfig;
 import io.harness.cf.model.Variation;
 import java.util.concurrent.Executors;
@@ -38,12 +39,13 @@ public class AnalyticsManager implements Destroyable {
     timerExecutorService = Executors.newSingleThreadScheduledExecutor();
   }
 
-  public AnalyticsManager(String environmentID, String cluster, String apiKey, Config config)
+  public AnalyticsManager(
+      DefaultApi metricsApi, String environmentID, String cluster, Config config)
       throws CfClientException {
 
     this.analyticsCache = AnalyticsCacheFactory.create(config.getAnalyticsCacheType());
     AnalyticsPublisherService analyticsPublisherService =
-        new AnalyticsPublisherService(apiKey, config, environmentID, cluster, analyticsCache);
+        new AnalyticsPublisherService(metricsApi, config, environmentID, cluster, analyticsCache);
     ringBuffer = createRingBuffer(config.getBufferSize(), analyticsPublisherService);
 
     TimerTask timerTask = new TimerTask(ringBuffer);

--- a/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/AnalyticsPublisherService.java
@@ -55,9 +55,13 @@ public class AnalyticsPublisherService {
   private final Config config;
 
   public AnalyticsPublisherService(
-      String apiKey, Config config, String environmentID, String cluster, Cache analyticsCache) {
+      DefaultApi metricsAPI,
+      Config config,
+      String environmentID,
+      String cluster,
+      Cache analyticsCache) {
 
-    metricsAPI = MetricsApiFactory.create(apiKey, config);
+    this.metricsAPI = metricsAPI;
     this.analyticsCache = analyticsCache;
     this.environmentID = environmentID;
     this.cluster = cluster;

--- a/src/main/java/io/harness/cf/client/api/analytics/MetricsApiFactory.java
+++ b/src/main/java/io/harness/cf/client/api/analytics/MetricsApiFactory.java
@@ -1,15 +1,10 @@
 package io.harness.cf.client.api.analytics;
 
 import com.google.common.base.Strings;
-import io.harness.cf.ApiException;
-import io.harness.cf.client.api.CfClientException;
-import io.harness.cf.client.api.Config;
-import io.harness.cf.client.api.DefaultApiFactory;
-import io.harness.cf.client.dto.AuthenticationRequestBuilder;
 import io.harness.cf.metrics.ApiClient;
 import io.harness.cf.metrics.api.DefaultApi;
-import io.harness.cf.model.AuthenticationResponse;
-import lombok.SneakyThrows;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,60 +21,34 @@ public class MetricsApiFactory {
   private static final long AUTH_RETRY_INTERNAL_MILLIS = 1000;
   private static final int AUTH_RETRY_MAX_RETRY_COUNT = 3;
 
-  @SneakyThrows
-  public static DefaultApi create(String apiKey, Config config) {
-    DefaultApi metricsAPI = new DefaultApi();
-    io.harness.cf.api.DefaultApi clientAPI =
-        DefaultApiFactory.create(
-            config.getConfigUrl(), config.getConnectionTimeout(),
-            config.getReadTimeout(), config.getWriteTimeout());
-    if (!Strings.isNullOrEmpty(config.getEventUrl())) {
-      ApiClient apiClient = metricsAPI.getApiClient();
-      apiClient.setBasePath(config.getEventUrl());
-      metricsAPI.setApiClient(apiClient);
-    }
+  public static DefaultApi create(
+      String basePath, int connectionTimeout, int readTimeout, int writeTimeout, boolean debug) {
 
-    int count = 0;
-    while (count < AUTH_RETRY_MAX_RETRY_COUNT) {
+    DefaultApi metricsAPI = new DefaultApi();
+    if (!Strings.isNullOrEmpty(basePath)) {
+      ApiClient apiClient = metricsAPI.getApiClient();
+      apiClient.setConnectTimeout(connectionTimeout);
+      apiClient.setReadTimeout(readTimeout);
+      apiClient.setWriteTimeout(writeTimeout);
+      apiClient.setBasePath(basePath);
+      apiClient.setDebugging(debug);
+      apiClient.setUserAgent("java " + io.harness.cf.Version.VERSION);
+      String hostname = "UnknownHost";
       try {
-        auth(metricsAPI, apiKey, clientAPI);
-        break;
-      } catch (Exception apiException) {
-        count++;
-        log.error("Failed to get auth token {}", apiException.getMessage());
-        Thread.sleep(AUTH_RETRY_INTERNAL_MILLIS);
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        log.warn("Unable to get hostname");
       }
+      apiClient.addDefaultHeader("Hostname", hostname);
+      metricsAPI.setApiClient(apiClient);
     }
 
     return metricsAPI;
   }
 
-  public static void auth(
-      DefaultApi metricsAPI, String apiKey, io.harness.cf.api.DefaultApi clientAPI)
-      throws CfClientException {
-    String authToken = getAuthToken(clientAPI, apiKey);
-    ApiClient apiClient = metricsAPI.getApiClient();
-    apiClient.addDefaultHeader("Authorization", "Bearer " + authToken);
-    metricsAPI.setApiClient(apiClient);
-  }
-
-  @SneakyThrows
-  public static String getAuthToken(io.harness.cf.api.DefaultApi defaultApi, String apiKey)
-      throws CfClientException {
-    AuthenticationResponse authResponse = null;
-
-    try {
-      authResponse =
-          defaultApi.authenticate(
-              AuthenticationRequestBuilder.anAuthenticationRequest().apiKey(apiKey).build());
-      return authResponse.getAuthToken();
-    } catch (ApiException apiException) {
-      if (apiException.getCode() == 401) {
-        throw new CfClientException(String.format("Invalid apiKey %s. Exiting. ", apiKey));
-      }
-      log.error("Failed to get auth token {}", apiException.getMessage());
-    }
-
-    return null;
+  public static void addAuthHeader(DefaultApi defaultApi, String jwtToken) {
+    ApiClient apiClient = defaultApi.getApiClient();
+    apiClient.addDefaultHeader("Authorization", "Bearer " + jwtToken);
+    defaultApi.setApiClient(apiClient);
   }
 }

--- a/src/test/java/io/harness/cf/client/api/mock/MockedAnalyticsManager.java
+++ b/src/test/java/io/harness/cf/client/api/mock/MockedAnalyticsManager.java
@@ -11,10 +11,8 @@ public class MockedAnalyticsManager extends AnalyticsManager {
 
   private MockedAnalyticsHandler analyticsEventHandler;
 
-  public MockedAnalyticsManager(String environmentID, String authToken, Config config)
-      throws CfClientException {
-
-    super(environmentID, "", authToken, config);
+  public MockedAnalyticsManager(String environmentID, Config config) throws CfClientException {
+    super(new io.harness.cf.metrics.api.DefaultApi(), environmentID, "", config);
   }
 
   @Nonnull

--- a/src/test/java/io/harness/cf/client/api/mock/MockedCfClient.java
+++ b/src/test/java/io/harness/cf/client/api/mock/MockedCfClient.java
@@ -32,7 +32,7 @@ public class MockedCfClient extends CfClient {
 
     if (analyticsManager == null) {
 
-      analyticsManager = new MockedAnalyticsManager(environmentID, "", config);
+      analyticsManager = new MockedAnalyticsManager(environmentID, config);
     }
     return analyticsManager;
   }


### PR DESCRIPTION
Currently the analytics manager enables a copy of the client API on startup,
however this is a static instance.
The problem when debug is enabled, that the manager didn't read the config, and so tries
to modify the static instance of the client API from a different thread (setting it to false, where as the main thread as set it to true).

This results in the manager throwing an exception and failing to start.
As a by product the isInitalize function will never return true.

What:
This change removes the second intialization of the static client API.  The client API is initalized from
the main constructor, so will already exist.
Instead of the analytics manager authenticating seperately it shares the same JWT as the the client API.