### PR TITLE
[MAINT] fix segments includes

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -92,14 +92,22 @@ class Evaluator implements Evaluation {
       return false;
     }
 
+    if (operator.equals(SEGMENT_MATCH)) {
+      return isTargetIncludedOrExcludedInSegment(clause.getValues(), target);
+    }
+
+    if (clause.getValues().size() == 0) {
+      return false;
+    }
+
+    String value = clause.getValues().get(0);
     Optional<Object> attrValue = getAttrValue(target, clause.getAttribute());
+
     if (!attrValue.isPresent()) {
       return false;
     }
 
     String object = attrValue.get().toString();
-    String value = clause.getValues().get(0);
-
     switch (operator) {
       case STARTS_WITH:
         return object.startsWith(value);
@@ -115,8 +123,6 @@ class Evaluator implements Evaluation {
         return object.equals(value);
       case IN:
         return value.contains(object);
-      case SEGMENT_MATCH:
-        return isTargetIncludedOrExcludedInSegment(clause.getValues(), target);
       default:
         return false;
     }

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -63,6 +63,10 @@ public class FFUseCaseTest {
                 testCase.getFileData().getFlag().getFeature(), target, new JsonObject(), null);
         break;
     }
-    Assert.assertEquals(testCase.getExpectedValue(), got);
+    String msg =
+        String.format(
+            "Test case: %s with identifier %s ",
+            testCase.getFile(), testCase.getTargetIdentifier());
+    Assert.assertEquals(testCase.getExpectedValue(), got, msg);
   }
 }


### PR DESCRIPTION
When clause field 'attribute' is empty and segmentMatch operator always return false

* Now it first checks operator segmentMatch and return evaluated value
* Then it checks other operators